### PR TITLE
feat: push HUD updates from server

### DIFF
--- a/client/hud.lua
+++ b/client/hud.lua
@@ -1,4 +1,15 @@
 local show = true
-RegisterCommand('hud', function() show = not show; SendNUIMessage({ type='vis', show=show }) end, false)
-CreateThread(function() SetNuiFocus(false,false); SendNUIMessage({ type='vis', show=show }); while true do Wait(750) TriggerServerEvent('fw:hud:pull') end end)
-RegisterNetEvent('fw:hud:snapshot', function(data) data.type='update'; SendNUIMessage(data) end)
+RegisterCommand('hud', function()
+  show = not show
+  SendNUIMessage({ type='vis', show = show })
+end, false)
+
+CreateThread(function()
+  SetNuiFocus(false, false)
+  SendNUIMessage({ type = 'vis', show = show })
+end)
+
+RegisterNetEvent('fw:hud:push', function(data)
+  data.type = 'update'
+  SendNUIMessage(data)
+end)

--- a/server/hud_data.lua
+++ b/server/hud_data.lua
@@ -1,5 +1,25 @@
--- HUD data stub to satisfy fxmanifest reference
--- You can expand this to push stamina/weight/temp to NUI periodically.
+-- Push HUD vitals to clients when they change
+
+local lastVitals = {}
+
 CreateThread(function()
-  -- Placeholder loop (disabled by default)
+  while true do
+    for _, src in ipairs(GetPlayers()) do
+      local ped = GetPlayerPed(src)
+      local hp = GetEntityHealth(ped)
+      local armor = GetPedArmour(ped)
+      local snapshot = { hp = hp, armor = armor }
+      local prev = lastVitals[src]
+      if not prev or prev.hp ~= hp or prev.armor ~= armor then
+        lastVitals[src] = snapshot
+        TriggerClientEvent('fw:hud:push', src, snapshot)
+      end
+    end
+    Wait(1000)
+  end
 end)
+
+AddEventHandler('playerDropped', function()
+  lastVitals[source] = nil
+end)
+

--- a/server/safenet_guard.lua
+++ b/server/safenet_guard.lua
@@ -3,7 +3,6 @@ FW.SafeGate = {}
 local keys = {
   ["evt:weap_shot"] = { rate=10, burst=15 },
   ["evt:veh_impact"] = { rate=2, burst=5 },
-  ["hud:pull"] = { rate=2, burst=4 },
   ["stash:open"] = { rate=1, burst=2 },
   ["stash:move"] = { rate=2, burst=5 },
   ["craft:do"] = { rate=1, burst=2 },


### PR DESCRIPTION
## Summary
- remove client polling loop and listen for `fw:hud:push`
- send HUD vitals from server only when they change
- drop unused `hud:pull` from SafeGate keys

## Testing
- `busted spec`
- ⚠️ `resmon` *(not run: requires FiveM runtime)*


------
https://chatgpt.com/codex/tasks/task_e_689ed3f993b483329cc9b2dc496d3157