### PR TITLE
Cache wildlife rules and track query rate

### DIFF
--- a/server/wildlife_smart.lua
+++ b/server/wildlife_smart.lua
@@ -5,7 +5,12 @@ local function getHour()
 end
 local function isNight() local h=getHour(); return (h>=20 or h<6) end
 
-local function rules()
+-- track DB queries to measure queries/min
+local qcount = 0
+local qstart = GetGameTimer()
+
+local function fetch_rules()
+  qcount = qcount + 1
   local q = [[
     SELECT r.rule_id, b.name biome, r.species, r.density, r.night_mult, r.rain_mult, r.group_min, r.group_max
     FROM wildlife_rules r JOIN biomes b ON b.biome_id=r.biome_id
@@ -13,10 +18,29 @@ local function rules()
   return MySQL.query.await(q, {}) or {}
 end
 
+local rules_cache = {}
+local rules_expire = 0
+local function refresh_rules()
+  rules_cache = fetch_rules()
+  rules_expire = GetGameTimer() + math.random(300000, 600000) -- 5-10 min TTL
+end
+
+-- expose manual refresh for admins
+RegisterCommand('wildrules', function(src)
+  if src ~= 0 then
+    local role = (FW.ACL and FW.ACL.RoleOf and FW.ACL.RoleOf(src)) or 'user'
+    if role ~= 'admin' then return end
+  end
+  refresh_rules()
+  if src ~= 0 then TriggerClientEvent('chat:addMessage', src, { args={'^2Wildlife','Rules refreshed'} }) end
+end, false)
+
 CreateThread(function()
+  refresh_rules()
   while true do
     Wait(15000)
-    local rs = rules()
+    if GetGameTimer() > rules_expire then refresh_rules() end
+    local rs = rules_cache
     local night = isNight()
     for _, r in ipairs(rs) do
       local dens = tonumber(r.density) or 0.2
@@ -29,5 +53,15 @@ CreateThread(function()
         TriggerEvent('fw:wildlife:spawn', { species = r.species, group = group, biome = r.biome, isNight = night })
       end
     end
+  end
+end)
+
+-- update metrics once per minute
+CreateThread(function()
+  while true do
+    Wait(60000)
+    local mins = (GetGameTimer() - qstart) / 60000
+    local qpm = qcount / (mins > 0 and mins or 1)
+    if FW.Metrics and FW.Metrics.SetG then FW.Metrics.SetG('wildlife_rules_db_qpm', qpm) end
   end
 end)


### PR DESCRIPTION
## Summary
- cache wildlife spawn rules and refresh on 5–10m TTL or manual command
- replace per-tick DB fetch with cached rules
- expose wildlife rule query rate via metric

## Testing
- `busted spec`

------
https://chatgpt.com/codex/tasks/task_e_689ed875c02c833299894e5497cf7e80