### PR TITLE
Add identity creation overlay

### DIFF
--- a/resources/sfw/client/11_identity.lua
+++ b/resources/sfw/client/11_identity.lua
@@ -10,6 +10,14 @@ end)
 
 RegisterNUICallback('id:submit', function(data, cb)
   TriggerServerEvent('fw:id:submit', data or {})
+  SetNuiFocus(false, false)
+  SendNUIMessage({ type='id:close' })
+  if cb then cb({ ok = true }) end
+end)
+
+RegisterNUICallback('id:cancel', function(data, cb)
+  SetNuiFocus(false, false)
+  SendNUIMessage({ type='id:close' })
   if cb then cb({ ok = true }) end
 end)
 

--- a/resources/sfw/nui/sfw_shell/app.js
+++ b/resources/sfw/nui/sfw_shell/app.js
@@ -11,15 +11,37 @@
   }
 
   const viewApp = $('#view-app');
+  const viewId = $('#view-id');
   function setView(name){
     viewApp.classList.add('hidden');
+    viewId.classList.add('hidden');
     if(name === 'app'){ viewApp.classList.remove('hidden'); }
+    if(name === 'id'){ viewId.classList.remove('hidden'); }
   }
 
   window.addEventListener('message', (e)=>{
     const d = e.data || {};
     if(d.type === 'app:open'){ setView('app'); }
     if(d.type === 'app:close'){ setView(null); }
+    if(d.type === 'id:open'){ setView('id'); }
+    if(d.type === 'id:close'){ setView(null); }
+  });
+
+  $('#id_form')?.addEventListener('submit', (e)=>{
+    e.preventDefault();
+    post('id:submit', {
+      first_name: $('#id_first')?.value || '',
+      last_name: $('#id_last')?.value || '',
+      dob: $('#id_dob')?.value || '',
+      sex: $('#id_sex')?.value || '',
+      height_cm: parseInt($('#id_height')?.value||'0',10) || 0,
+      blood_type: $('#id_blood')?.value || '',
+      nationality: $('#id_nation')?.value || ''
+    });
+  });
+
+  $('#id_cancel')?.addEventListener('click', ()=>{
+    post('id:cancel', {});
   });
 
   $('#ap_apply')?.addEventListener('click', ()=>{

--- a/resources/sfw/nui/sfw_shell/index.html
+++ b/resources/sfw/nui/sfw_shell/index.html
@@ -10,6 +10,33 @@
 <body>
   <div id="hud" class="panel">HUD...</div>
 
+  <!-- Identity form -->
+  <div id="view-id" class="overlay hidden">
+    <div class="card">
+      <h2>Identity</h2>
+      <form id="id_form">
+        <div class="grid">
+          <label>First Name: <input id="id_first" name="first_name" type="text" maxlength="64"></label>
+          <label>Last Name: <input id="id_last" name="last_name" type="text" maxlength="64"></label>
+          <label>Date of Birth: <input id="id_dob" name="dob" type="date"></label>
+          <label>Sex:
+            <select id="id_sex" name="sex">
+              <option value="M">Male</option>
+              <option value="F">Female</option>
+            </select>
+          </label>
+          <label>Height (cm): <input id="id_height" name="height_cm" type="number" min="120" max="220" value="175"></label>
+          <label>Blood Type: <input id="id_blood" name="blood_type" type="text" maxlength="8"></label>
+          <label>Nationality: <input id="id_nation" name="nationality" type="text" maxlength="64"></label>
+        </div>
+        <div class="actions">
+          <button type="submit" id="id_submit">Submit</button>
+          <button type="button" id="id_cancel">Cancel</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
   <!-- Appearance (hair only, clothing locked) -->
   <div id="view-app" class="overlay hidden">
     <div class="card">

--- a/resources/sfw/nui/sfw_shell/style.css
+++ b/resources/sfw/nui/sfw_shell/style.css
@@ -14,3 +14,6 @@ label { display:flex; flex-direction:column; font-size: 14px; }
 input, select, button { background: #001800; color:#bfffbf; border:1px solid #0f0; padding:6px; }
 button { cursor:pointer; }
 button:hover { background:#002800; }
+
+#view-id .card { width: 600px; }
+#view-id .actions { margin-top:16px; display:flex; justify-content:flex-end; gap:8px; }


### PR DESCRIPTION
## Summary
- add NUI identity overlay with registration fields
- wire JS events for id open/close and submission
- style identity screen and close focus on submit/cancel

## Testing
- `busted spec`


------
https://chatgpt.com/codex/tasks/task_e_689ef6f210cc8332bf895f76d475096d