### PR TITLE
refactor: isolate inventory callbacks and weapon debug commands

### DIFF
--- a/resources/sfw/client/20_inventory.lua
+++ b/resources/sfw/client/20_inventory.lua
@@ -1,14 +1,6 @@
 RegisterNetEvent('fw:inv:toast', function(msg)
   SendNUIMessage({action='inv:toast', text=msg})
 end)
-
-RegisterNUICallback('inv:moveStrict', function(d, cb)
-  TriggerServerEvent('fw:inv:moveStrict', d)
-  cb({ ok = true })
-end)
-RegisterNUICallback('inv:move', function(data, cb) -- passthrough to server (already registered there)
-  cb({ ok=true })
-end)
 RegisterNetEvent('fw:player:register_mode', function(enabled)
   local ped = PlayerPedId()
   if enabled then
@@ -25,54 +17,6 @@ RegisterCommand('fw_unhide', function()
   FreezeEntityPosition(ped, false)
   SetEntityVisible(ped, true, false)
 end, false)
-local state = { weapon = 'DEMO', mag = 0, chamber = 0, jam = false }
-
-local function push()
-  TriggerEvent('fw:weap:state', state)
-end
-
-RegisterCommand('magfill', function()
-  state.mag = 30
-  state.chamber = 1
-  state.jam = false
-  push()
-end, false)
-
-RegisterCommand('magunload', function()
-  state.mag = 0
-  state.chamber = 0
-  push()
-end, false)
-
-RegisterCommand('swapmag', function()
-  state.mag = math.random(5, 30)
-  push()
-end, false)
-
-RegisterCommand('weapjam', function()
-  state.jam = not state.jam
-  push()
-end, false)
-
--- Example hooks: In your weapon handling, trigger these appropriately.
--- Here we simulate for testing with simple commands.
-
-RegisterCommand('weap_state', function(_, args)
-  local wtype = args[1] or 'AR'
-  local cap = tonumber(args[2] or '30')
-  local rounds = tonumber(args[3] or '30')
-  local chamber = tonumber(args[4] or '1')
-  SendNUIMessage({ type='update', wtype=wtype, wmagMax=cap, wmagRounds=rounds, wchamber=chamber })
-  TriggerServerEvent('fw:weap:update', { wtype=wtype, magMax=cap, magRounds=rounds, chamber=chamber, cond=100.0, heat=0.0, jam=false })
-end, false)
-
-RegisterCommand('weap_shot', function(_, args)
-  local q = (args[1] or 'normal') -- ammo quality
-  TriggerServerEvent('fw:weap:shot', q)
-end, false)
-
-RegisterCommand('weap_clear', function() TriggerServerEvent('fw:weap:clearjam') end, false)
-RegisterCommand('weap_swap', function(_, args) TriggerServerEvent('fw:weap:swapmag', tonumber(args[1] or '30'), tonumber(args[2] or '30')) end, false)
 local function hash(name) return GetHashKey(name) end
 local map = (FW and FW.WeapCompat and FW.WeapCompat.weapons) or {}
 

--- a/resources/sfw/client/95_weap_debug.lua
+++ b/resources/sfw/client/95_weap_debug.lua
@@ -1,0 +1,55 @@
+-- SFW — Weapon Debug Commands
+
+if GetConvar('sfw_dev', 'false') == 'true' then
+  local state = { weapon = 'DEMO', mag = 0, chamber = 0, jam = false }
+
+  local function push()
+    TriggerEvent('fw:weap:state', state)
+  end
+
+  RegisterCommand('magfill', function()
+    state.mag = 30
+    state.chamber = 1
+    state.jam = false
+    push()
+  end, false)
+
+  RegisterCommand('magunload', function()
+    state.mag = 0
+    state.chamber = 0
+    push()
+  end, false)
+
+  RegisterCommand('swapmag', function()
+    state.mag = math.random(5, 30)
+    push()
+  end, false)
+
+  RegisterCommand('weapjam', function()
+    state.jam = not state.jam
+    push()
+  end, false)
+
+  RegisterCommand('weap_state', function(_, args)
+    local wtype = args[1] or 'AR'
+    local cap = tonumber(args[2] or '30')
+    local rounds = tonumber(args[3] or '30')
+    local chamber = tonumber(args[4] or '1')
+    SendNUIMessage({ type='update', wtype=wtype, wmagMax=cap, wmagRounds=rounds, wchamber=chamber })
+    TriggerServerEvent('fw:weap:update', { wtype=wtype, magMax=cap, magRounds=rounds, chamber=chamber, cond=100.0, heat=0.0, jam=false })
+  end, false)
+
+  RegisterCommand('weap_shot', function(_, args)
+    local q = (args[1] or 'normal')
+    TriggerServerEvent('fw:weap:shot', q)
+  end, false)
+
+  RegisterCommand('weap_clear', function()
+    TriggerServerEvent('fw:weap:clearjam')
+  end, false)
+
+  RegisterCommand('weap_swap', function(_, args)
+    TriggerServerEvent('fw:weap:swapmag', tonumber(args[1] or '30'), tonumber(args[2] or '30'))
+  end, false)
+end
+

--- a/resources/sfw/fxmanifest.lua
+++ b/resources/sfw/fxmanifest.lua
@@ -50,5 +50,6 @@ client_scripts {
   'client/40_ui.lua',
   'client/60_wildlife.lua',
   'client/70_env.lua',
-  'client/90_admin.lua'
+  'client/90_admin.lua',
+  'client/95_weap_debug.lua'
 }


### PR DESCRIPTION
## Summary
- remove inventory move callbacks from `20_inventory.lua` and rely on UI layer
- isolate weapon testing commands in `95_weap_debug.lua` gated by `sfw_dev`
- include new debug module in `fxmanifest.lua`

## Testing
- `apt-get install -y luacheck` *(fails: Unable to locate package luacheck)*
- `luac -p resources/sfw/client/20_inventory.lua resources/sfw/client/95_weap_debug.lua resources/sfw/client/40_ui.lua`

------
https://chatgpt.com/codex/tasks/task_e_689f0e59c3a083328ea104c9f4c7922a